### PR TITLE
Make a configuration option to turn ImageMagick on/off

### DIFF
--- a/web/src/components/BearHead/index.tsx
+++ b/web/src/components/BearHead/index.tsx
@@ -2,7 +2,7 @@ import { GenericVideoComponentProps } from '@interfaces/component-props';
 import { Pose } from '@tensorflow-models/pose-detection';
 import { useEffect, useRef, useState } from 'react';
 
-import { log } from '@utils/constants';
+import { log, MAGICK_ENABLED } from '@utils/constants';
 import { drawBearHead } from '@utils/drawing';
 import { FPSAnalyzer, FPSAnalyzerError } from '@utils/fps';
 import { getPoses } from '@utils/keypoints';
@@ -67,7 +67,9 @@ export function BearHead({
           drawBearHead(ctx, keypoints, tobyHead);
         });
 
-        setCountdown(magickCheck(poses));
+        if (MAGICK_ENABLED) {
+          setCountdown(magickCheck(poses));
+        }
 
         try {
           stats.current?.update();

--- a/web/src/components/Wireframe/index.tsx
+++ b/web/src/components/Wireframe/index.tsx
@@ -2,7 +2,7 @@ import { StaticBackgroundVideoComponentProps } from '@interfaces/component-props
 import { Pose } from '@tensorflow-models/pose-detection';
 import { useEffect, useRef, useState } from 'react';
 
-import { log } from '@utils/constants';
+import { log, MAGICK_ENABLED } from '@utils/constants';
 import { drawKeypoints, drawSkeleton } from '@utils/drawing';
 import { FPSAnalyzer, FPSAnalyzerError } from '@utils/fps';
 import { getPoses } from '@utils/keypoints';
@@ -65,7 +65,9 @@ export function Wireframe({
           drawKeypoints(ctx, keypoints, minPartConfidence);
         });
 
-        setCountdown(magickCheck(poses));
+        if (MAGICK_ENABLED) {
+          setCountdown(magickCheck(poses));
+        }
 
         try {
           stats.current?.update();

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -4,6 +4,7 @@ body {
     'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow: hidden;
 }
 
 code {
@@ -11,8 +12,8 @@ code {
 }
 
 #video-output {
-  width: 1920px;
-  height: 1080px;
+  width: 100%;
+  height: 100%;
   background-color: #666;
 }
 

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -89,7 +89,7 @@ export const MODEL_CONFIG: EnvModelConfig = (() => {
 export const FLASK_URL: string = 'http://127.0.0.1:5000';
 
 /**
- * To see if the application should have ImageMagick running, default to true
+ * To see if the application should have ImageMagick running, default to false
  */
 export const MAGICK_ENABLED: boolean = (() => {
   let magick = process.env.REACT_APP_MAGICK_ENABLED;

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -97,6 +97,7 @@ export const MAGICK_ENABLED: boolean = (() => {
     try {
       return parseInt(magick) > 0;
     } catch (_) {
+      log.error(`Could not not parse environment variable MAGICK_ENABLED: ${magick} provided`);
       return false;
     }
   }

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -60,7 +60,6 @@ interface EnvModelConfig {
  */
 export const MODEL_CONFIG: EnvModelConfig = (() => {
   const modelName = process.env.REACT_APP_MODEL;
-  log.fatal(modelName);
   if (modelName === 'PoseNet') {
     return {
       model: SupportedModels.PoseNet,
@@ -88,3 +87,18 @@ export const MODEL_CONFIG: EnvModelConfig = (() => {
  * Flask API for converting images
  */
 export const FLASK_URL: string = 'http://127.0.0.1:5000';
+
+/**
+ * To see if the application should have ImageMagick running, default to true
+ */
+export const MAGICK_ENABLED: boolean = (() => {
+  let magick = process.env.REACT_APP_MAGICK_ENABLED;
+  if (magick) {
+    try {
+      return parseInt(magick) > 0;
+    } catch (_) {
+      return false;
+    }
+  }
+  return false;
+})();


### PR DESCRIPTION
This is used for using turning on/off ImageMagick so the application can be used in Willet's hallway without ImageMagick randomly appearing. Once a more organized and agreed upon way of setting up ImageMagick is found, this setting can be set to true for the hallway app.