### PR TITLE
Address #8 by moving bear head init into constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+*.lnk

--- a/web/src/components/BearHead/index.tsx
+++ b/web/src/components/BearHead/index.tsx
@@ -2,7 +2,7 @@ import { GenericVideoComponentProps } from '@interfaces/component-props';
 import { Pose } from '@tensorflow-models/pose-detection';
 import { useEffect, useRef, useState } from 'react';
 
-import { log, MAGICK_ENABLED } from '@utils/constants';
+import { log, MAGICK_ENABLED, tobyHead } from '@utils/constants';
 import { drawBearHead } from '@utils/drawing';
 import { FPSAnalyzer, FPSAnalyzerError } from '@utils/fps';
 import { getPoses } from '@utils/keypoints';
@@ -31,11 +31,7 @@ export function BearHead({
   const requestAnimationId = useRef<number | null>(null);
   const stats = useRef<FPSAnalyzer>();
   const [countdown, setCountdown] = useState<number>(4000);
-  const tobyHead: HTMLImageElement = (() => {
-    const img = new Image();
-    img.src = require('@utils/toby.png');
-    return img;
-  })();
+
 
   /**
    * Start the animation frames

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -16,6 +16,15 @@ import { Logger } from 'tslog';
 export const MODE_SWITCH_DELAY = 10_000;
 
 /**
+ * TobyHead to be displayed in the BearHead component. Should only be loaded once.
+ */
+export const tobyHead: HTMLImageElement = (() => {
+  const img = new Image();
+  img.src = require('@utils/toby.png');
+  return img;
+})();
+
+/**
  * Custom logger for debugging.
  */
 export const log = new Logger({


### PR DESCRIPTION
Potential cause of crash is due to bear head loading every time the page renders. Change to where the `toby.png` file is initialized in the constants to prevent too many files from being opened.